### PR TITLE
Add VectorLabel Drawer

### DIFF
--- a/Editor/Drawers.cs
+++ b/Editor/Drawers.cs
@@ -1190,11 +1190,7 @@ namespace Thry
 
     public class VectorLabelDrawer : MaterialPropertyDrawer
     {
-        string _labelX = "X";
-        string _labelY = "Y";
-        string _labelZ = "Z";
-        string _labelW = "W";
-        string[] _labelStrings = new string[4];
+        string[] _labelStrings = new string[4] {"X", "Y", "Z", "W"};
         int vectorChannels = 0;
 
         public VectorLabelDrawer(string labelX, string labelY)
@@ -1229,8 +1225,6 @@ namespace Thry
             Rect labelR     = new Rect(position.x,                position.y, position.width * 0.41f,        position.height);
             Rect contentR   = new Rect(position.x + labelR.width, position.y, position.width - labelR.width, position.height);
 
-            // float[] values = new float[] {prop.vectorValue.x, prop.vectorValue.y, prop.vectorValue.z, prop.vectorValue.w};
-            // GUIContent[] labels = new GUIContent[] { new GUIContent(_labelX), new GUIContent(_labelY), new GUIContent(_labelZ), new GUIContent(_labelW) }
             float[] values = new float[vectorChannels];
             GUIContent[] labels = new GUIContent[vectorChannels];
 
@@ -1245,7 +1239,20 @@ namespace Thry
 
             if (EditorGUI.EndChangeCheck())
             {
-                prop.vectorValue = new Vector4(values[0], values[1], values[2], values[3]);
+                switch(vectorChannels)
+                {
+                    case 2:
+                        prop.vectorValue = new Vector4(values[0], values[1], prop.vectorValue.z, prop.vectorValue.w);
+                        break;
+                    case 3:
+                        prop.vectorValue = new Vector4(values[0], values[1], values[2], prop.vectorValue.w);
+                        break;
+                    case 4:
+                        prop.vectorValue = new Vector4(values[0], values[1], values[2], values[3]);
+                        break;
+                    default:
+                        break;
+                }
             }
         }
 

--- a/Editor/Drawers.cs
+++ b/Editor/Drawers.cs
@@ -1188,6 +1188,74 @@ namespace Thry
         }
     }
 
+    public class VectorLabelDrawer : MaterialPropertyDrawer
+    {
+        string _labelX = "X";
+        string _labelY = "Y";
+        string _labelZ = "Z";
+        string _labelW = "W";
+        string[] _labelStrings = new string[4];
+        int vectorChannels = 0;
+
+        public VectorLabelDrawer(string labelX, string labelY)
+        {
+            _labelStrings[0] = labelX;
+            _labelStrings[1] = labelY;
+            vectorChannels = 2;
+        }
+
+        public VectorLabelDrawer(string labelX, string labelY, string labelZ)
+        {
+            _labelStrings[0] = labelX;
+            _labelStrings[1] = labelY;
+            _labelStrings[2] = labelZ;
+            vectorChannels = 3;
+        }
+
+        public VectorLabelDrawer(string labelX, string labelY, string labelZ, string labelW)
+        {
+            _labelStrings[0] = labelX;
+            _labelStrings[1] = labelY;
+            _labelStrings[2] = labelZ;
+            _labelStrings[3] = labelW;
+            vectorChannels = 4;
+        }
+
+        public override void OnGUI(Rect position, MaterialProperty prop, GUIContent label, MaterialEditor editor)
+        {
+            EditorGUI.BeginChangeCheck();
+            EditorGUI.showMixedValue = prop.hasMixedValue;
+
+            Rect labelR     = new Rect(position.x,                position.y, position.width * 0.41f,        position.height);
+            Rect contentR   = new Rect(position.x + labelR.width, position.y, position.width - labelR.width, position.height);
+
+            // float[] values = new float[] {prop.vectorValue.x, prop.vectorValue.y, prop.vectorValue.z, prop.vectorValue.w};
+            // GUIContent[] labels = new GUIContent[] { new GUIContent(_labelX), new GUIContent(_labelY), new GUIContent(_labelZ), new GUIContent(_labelW) }
+            float[] values = new float[vectorChannels];
+            GUIContent[] labels = new GUIContent[vectorChannels];
+
+            for (int i = 0; i < vectorChannels; i++)
+            {
+                values[i] = prop.vectorValue[i];
+                labels[i] = new GUIContent(_labelStrings[i]);
+            }
+
+            EditorGUI.LabelField(labelR, label);
+            EditorGUI.MultiFloatField(contentR, labels, values);
+
+            if (EditorGUI.EndChangeCheck())
+            {
+                prop.vectorValue = new Vector4(values[0], values[1], values[2], values[3]);
+            }
+        }
+
+        public override float GetPropertyHeight(MaterialProperty prop, string label, MaterialEditor editor)
+        {
+            DrawingData.LastPropertyUsedCustomDrawer = true;
+            return base.GetPropertyHeight(prop, label, editor);
+        }
+    }
+
     public class HelpboxDrawer : MaterialPropertyDrawer
     {
         readonly MessageType type;


### PR DESCRIPTION
adds [VectorLabel] drawer, takes 2, 3, or 4 label strings and will display 2, 3, or 4 components respectively

example usage: 
```cs
[VectorLabel(minX, minY, maxX, maxY)]_AudioLinkDecal0Scale ("Scale Mod", Vector) = (0, 0, 0, 0)
[VectorLabel(Min, Max)]_AudioLinkDecal0Rotation ("Rotation Mod", Vector) = (0, 0, 0, 0)
```
Produces:
![Unity_H7rYfri2JK](https://user-images.githubusercontent.com/47901762/185769066-08342921-e7d1-496e-8bb4-85075d8f1532.png)

