### PR TITLE
Force Async Compilation in Preview of Editor

### DIFF
--- a/Editor/Config.cs
+++ b/Editor/Config.cs
@@ -80,6 +80,7 @@ namespace Thry
         public string anchorOverrideObjectName = "AutoAnchorObject";
         public bool autoSetAnchorAskedOnce = false;
         public bool enableDeveloperMode = false;
+        public bool forceAsyncCompilationPreview = true;
 
         public string verion = VERSION;
 

--- a/Editor/Settings.cs
+++ b/Editor/Settings.cs
@@ -166,6 +166,9 @@ namespace Thry
             Text("anchorOverrideObjectName");
 
             EditorGUILayout.Space();
+            Toggle("forceAsyncCompilationPreview");
+
+            EditorGUILayout.Space();
             GUILayout.Label(EditorLocale.editor.Get("developer_header"), EditorStyles.boldLabel);
             Toggle("showManualReloadButton");
             Toggle("enableDeveloperMode");

--- a/Editor/ThryEditor.cs
+++ b/Editor/ThryEditor.cs
@@ -398,6 +398,19 @@ namespace Thry
 
             AddResetProperty();
 
+            bool setForceAsyncCompilationPreview = SessionState.GetBool("ThrySetForceAsyncCompilationPreview", false);
+
+            if(Config.Singleton.forceAsyncCompilationPreview && !setForceAsyncCompilationPreview)
+            {
+                SessionState.SetBool("ThrySetForceAsyncCompilationPreview", true);
+                ShaderUtil.allowAsyncCompilation = true;
+            }
+            else if(setForceAsyncCompilationPreview)
+            {
+                SessionState.SetBool("ThrySetForceAsyncCompilationPreview", false);
+                ShaderUtil.allowAsyncCompilation = false;
+            }
+
             _isFirstOnGUICall = false;
         }
 

--- a/thry_editor_locale.csv
+++ b/thry_editor_locale.csv
@@ -65,6 +65,8 @@ anchorOverrideObjectName_tooltip,Name of a GameObject somewhere in your avatar's
 autoAnchorDialog_Title,Thry: Bad Lighting Fix,,,,,,,,
 autoAnchorDialog_Text,Your avatar's renderers don't all have an anchor override set.\nThis can cause flickering and uneven lighting on your avatar in some worlds.\n\nWould you like this to always be fixed automatically?\n\nYou can change this in Thry settings at any time.,,,,,,,,
 autoAnchorError_NotHumanoid,Auto Anchor Setter: Avatar {0} is not humanoid or is missing an Animator.,,,,,,,,
+forceAsyncCompilationPreview,Force Async Compilation In Preview,,,,,,,,
+forceAsyncCompilationPreview_tooltip,Speeds up compilation time and doesn't block UI during compilation.,,,,,,,,
 enableDeveloperMode,Developer Mode,,,,,,,,
 enableDeveloperMode_tooltip,Enables developer mode. This will show additional options and information in the Shader UI.,,,,,,,,
 ,,,,,,,,,


### PR DESCRIPTION
Speeds up compilation by allowing dispatch of multiple threads, and doesn't block GUI. Unity bad.