### PR TITLE
Auto Anchor Setter improvements

### DIFF
--- a/Editor/UploadAnchorOverrideSetter.cs
+++ b/Editor/UploadAnchorOverrideSetter.cs
@@ -9,6 +9,8 @@ namespace Pumkin.UploadCallbacks
 {
     public static class UploadAnchorOverrideSetter
     {
+        const string SkipAvatarObjectName = "AutoAnchorDisabled";
+
         static readonly Type[] RendererTypesToCheck =
         {
             typeof(SkinnedMeshRenderer),
@@ -38,6 +40,9 @@ namespace Pumkin.UploadCallbacks
 
         public static void SetAnchorOverrides(GameObject avatarGameObject)
         {
+            if(avatarGameObject.transform.Find(SkipAvatarObjectName))
+                return;
+            
             Renderer[] renderersWithNoAnchors = null;
             if(!AskedOnce) // If we haven't already asked, only display dialog once a renderer with no anchors is found
             {

--- a/Editor/UploadAnchorOverrideSetter.cs
+++ b/Editor/UploadAnchorOverrideSetter.cs
@@ -38,11 +38,13 @@ namespace Pumkin.UploadCallbacks
         static HumanBodyBones HumanBoneAnchor => Config.Singleton.humanBoneAnchor;
         static string AnchorName => Config.Singleton.anchorOverrideObjectName;
 
+        public static bool ShouldSkipAvatar(GameObject avatar)
+        {
+            return avatar.transform.Find(SkipAvatarObjectName);
+        }
+
         public static void SetAnchorOverrides(GameObject avatarGameObject)
         {
-            if(avatarGameObject.transform.Find(SkipAvatarObjectName))
-                return;
-            
             Renderer[] renderersWithNoAnchors = null;
             if(!AskedOnce) // If we haven't already asked, only display dialog once a renderer with no anchors is found
             {

--- a/Editor/UploadAnchorOverrideSetter.cs
+++ b/Editor/UploadAnchorOverrideSetter.cs
@@ -40,7 +40,7 @@ namespace Pumkin.UploadCallbacks
 
         public static bool ShouldSkipAvatar(GameObject avatar)
         {
-            return avatar.transform.Find(SkipAvatarObjectName);
+            return avatar.GetComponentsInChildren<Transform>(true).Any(t => t.name == SkipAvatarObjectName);
         }
 
         public static void SetAnchorOverrides(GameObject avatarGameObject)

--- a/Editor/UploadAnchorOverrideSetter.cs
+++ b/Editor/UploadAnchorOverrideSetter.cs
@@ -1,13 +1,20 @@
-﻿using System;
+using System;
 using System.Linq;
 using Thry;
 using UnityEditor;
 using UnityEngine;
+using UnityEngine.Rendering;
 
 namespace Pumkin.UploadCallbacks
 {
     public static class UploadAnchorOverrideSetter
     {
+        static readonly Type[] RendererTypesToCheck =
+        {
+            typeof(SkinnedMeshRenderer),
+            typeof(MeshRenderer)
+        };
+
         static string DialogTitle => EditorLocale.editor.Get("autoAnchorDialog_Title");
         static string DialogMessage => EditorLocale.editor.Get("autoAnchorDialog_Text");
         static string DialogYes => $"{EditorLocale.editor.Get("yes")} ({EditorLocale.editor.Get("recommended")})";
@@ -34,7 +41,7 @@ namespace Pumkin.UploadCallbacks
             Renderer[] renderersWithNoAnchors = null;
             if(!AskedOnce) // If we haven't already asked, only display dialog once a renderer with no anchors is found
             {
-                renderersWithNoAnchors = avatarGameObject.GetComponentsInChildren<Renderer>(true)?.Where(r => r.probeAnchor == null).ToArray();
+                renderersWithNoAnchors = avatarGameObject.GetComponentsInChildren<Renderer>(true)?.Where(ShouldCheckRenderer).ToArray();
 
                 if(renderersWithNoAnchors == null || renderersWithNoAnchors.Length == 0)
                     return;
@@ -48,7 +55,7 @@ namespace Pumkin.UploadCallbacks
                 return;
 
             if(renderersWithNoAnchors == null)
-                renderersWithNoAnchors = avatarGameObject.GetComponentsInChildren<Renderer>(true)?.Where(r => r.probeAnchor == null).ToArray();
+                renderersWithNoAnchors = avatarGameObject.GetComponentsInChildren<Renderer>(true)?.Where(ShouldCheckRenderer).ToArray();
 
             if(renderersWithNoAnchors == null || renderersWithNoAnchors.Length == 0)
                 return;
@@ -82,6 +89,15 @@ namespace Pumkin.UploadCallbacks
                 render.probeAnchor = anchorObject;
                 Debug.Log($"Thry: Setting Anchor Override for {render.name} to {anchorName}");
             }
+        }
+
+        static bool ShouldCheckRenderer(Renderer renderer)
+        {
+            if(renderer == null || !RendererTypesToCheck.Contains(renderer.GetType()))
+                return false;
+            if(renderer.reflectionProbeUsage == ReflectionProbeUsage.Off && renderer.lightProbeUsage == LightProbeUsage.Off)
+                return false;
+            return renderer.probeAnchor == null;
         }
     }
 }

--- a/External/Editor/AbiAutoAnchor.cs
+++ b/External/Editor/AbiAutoAnchor.cs
@@ -1,4 +1,4 @@
-﻿#if CVR_CCK_EXISTS
+#if CVR_CCK_EXISTS
 using System;
 using UnityEngine;
 using UnityEditor;
@@ -18,7 +18,8 @@ namespace Pumkin.UploadCallbacks
         {
             try
             {
-                UploadAnchorOverrideSetter.SetAnchorOverrides(uploadedObject);
+                if(!UploadAnchorOverrideSetter.ShouldSkipAvatar(uploadedObject))
+                    UploadAnchorOverrideSetter.SetAnchorOverrides(uploadedObject);
             }
             catch(Exception ex)
             {

--- a/External/Editor/VRCAutoAnchor.cs
+++ b/External/Editor/VRCAutoAnchor.cs
@@ -1,4 +1,4 @@
-﻿#if VRC_SDK_VRCSDK2 || VRC_SDK_VRCSDK3
+#if VRC_SDK_VRCSDK2 || VRC_SDK_VRCSDK3
 using System;
 using UnityEngine;
 using VRC.SDKBase.Editor.BuildPipeline;
@@ -13,7 +13,8 @@ namespace Pumkin.UploadCallbacks
         {
             try
             {
-                UploadAnchorOverrideSetter.SetAnchorOverrides(avatarGameObject);
+                if(!UploadAnchorOverrideSetter.ShouldSkipAvatar(avatarGameObject))
+                    UploadAnchorOverrideSetter.SetAnchorOverrides(avatarGameObject);
             }
             catch(Exception ex)
             {


### PR DESCRIPTION
- Skip checking avatar if object named "AutoAnchorDisabled" is child of avatar root.
- Only check Skinned Mesh and Mesh Renderers.
- Skip renderers that don't use reflection and light probes.