### PR TITLE
assumption-free approach

### DIFF
--- a/Editor/Helpers/Converter.cs
+++ b/Editor/Helpers/Converter.cs
@@ -376,7 +376,7 @@ namespace Thry
             List<Texture2D> gifFrames = new List<Texture2D>();
 #if SYSTEM_DRAWING
             var gifImage = System.Drawing.Image.FromFile(path);
-            var dimension = new System.Drawing.Imaging.FrameDimension(gifImage.FrameDimensionsList[0]);
+            var dimension = System.Drawing.Imaging.FrameDimension.Time;
 
             int width = Mathf.ClosestPowerOfTwo(gifImage.Width - 1);
             int height = Mathf.ClosestPowerOfTwo(gifImage.Height - 1);
@@ -390,7 +390,8 @@ namespace Thry
             {
                 gifImage.SelectActiveFrame(dimension, i);
                 var ogframe = new System.Drawing.Bitmap(gifImage.Width, gifImage.Height);
-                System.Drawing.Graphics.FromImage(ogframe).DrawImage(gifImage, System.Drawing.Point.Empty);
+                var canvas = System.Drawing.Graphics.FromImage(ogframe);
+                canvas.DrawImage(gifImage, canvas.RenderingOrigin);
                 var frame = ResizeBitmap(ogframe, width, height);
 
                 Texture2D frameTexture = new Texture2D(frame.Width, frame.Height);


### PR DESCRIPTION
`gifImage.FrameDimensionsList[0]` is assumed to be `FrameDimension.Time`, which isn't guaranteed.

therefore, in this commit, `FrameDimension.Time` is used directly instead.


same goes for `.DrawImage(gifImage, Point.Empty)`, where `(0, 0)` is assumed to be the origin, which again, isn't necessarily the case for every single GIF-based image.

therefore, the origin is obtained from the GIF image itself using `canvas.RenderingOrigin`.