### PR TITLE
CrossEditor and asset context menu improvements

### DIFF
--- a/Editor/CrossEditor.cs
+++ b/Editor/CrossEditor.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
 using UnityEngine;
@@ -7,37 +8,39 @@ namespace Thry
 {
     public class CrossEditor : EditorWindow
     {
+        private static CrossEditor GetInstance()
+        {
+            CrossEditor window = GetWindow(typeof(CrossEditor)) as CrossEditor;
+            window.name = "Cross Shader Editor";
+
+            return window;
+        }
+
         [MenuItem("Thry/Cross Shader Editor", priority = -20)]
         public static void ShowWindow()
         {
-            CrossEditor window = EditorWindow.GetWindow(typeof(CrossEditor)) as CrossEditor;
-            window.name = "Cross Shader Editor";
+            GetInstance();
         }
 
-        [MenuItem("Assets/Thry/Materials/Open in Cross Shader Editor", false , 400)]
-        public static void OpenInCrossShaderEditor()
+        [MenuItem("Assets/Thry/Materials/Add to Cross Shader Editor", false , 400)]
+        private static void OpenInCrossShaderEditor()
         {
-            CrossEditor window = EditorWindow.GetWindow(typeof(CrossEditor)) as CrossEditor;
-            window.name = "Cross Shader Editor";
-            window._materialList = Selection.objects.Where(o => o is Material).Cast<Material>().ToList();
-            window.UpdateTargets();
-            window._shaderEditor = null;
+            List<Material> materials = ShaderOptimizer.FindMaterials(ShaderOptimizer.GetSelectedFolders());
+            materials.AddRange(Selection.objects.Where(o => o is Material).Cast<Material>());
+
+            GetInstance().UpdateTargets(materials, true);
         }
 
-        [MenuItem("Assets/Thry/Materials/Open in Cross Shader Editor", true, 400)]
-        public static bool OpenInCrossShaderEditorValidation()
+        [MenuItem("Assets/Thry/Materials/Add to Cross Shader Editor", true, 400)]
+        private static bool OpenInCrossShaderEditorValidation()
         {
-            return Selection.objects.All(o => o is Material);
+            return Selection.objects.Any(o => o is Material) || ShaderOptimizer.GetSelectedFolders().Count() > 0;
         }
 
         [MenuItem("GameObject/Thry/Materials/Open All in Cross Shader Editor", false, 10)]
-        public static void OpenAllInCrossShaderEditor()
+        private static void OpenAllInCrossShaderEditor()
         {
-            CrossEditor window = EditorWindow.GetWindow(typeof(CrossEditor)) as CrossEditor;
-            window.name = "Cross Shader Editor";
-            window._materialList = Selection.gameObjects.SelectMany(o => o.GetComponentsInChildren<Renderer>(true)).SelectMany(r => r.sharedMaterials).ToList();
-            window.UpdateTargets();
-            window._shaderEditor = null;
+            GetInstance().UpdateTargets(Selection.gameObjects.SelectMany(o => o.GetComponentsInChildren<Renderer>(true)).SelectMany(r => r.sharedMaterials));
         }
 
         List<Material> _materialList = new List<Material>();
@@ -48,13 +51,27 @@ namespace Thry
         MaterialProperty[] _materialProperties = null;
         Vector2 _scrollPosition = Vector2.zero;
         bool _showMaterials = true;
+        Lazy<GUIStyle> LeftMargin = new Lazy<GUIStyle>(() => new GUIStyle() { margin = new RectOffset(30, 0, 0, 0) });
 
-        void UpdateTargets()
+        private void UpdateTargets(IEnumerable<Material> materials, bool add = false)
         {
-            bool isShaderBroken (Shader s) => s == null || s.name == "Hidden/InternalErrorShader";
+            _materialList = (add ?
+                _materialList.Concat(materials) : // add
+                materials) // replace
+                .Distinct().ToList(); // deduplicate
+
+            UpdateTargets();
+        }
+
+        private void UpdateTargets()
+        {
+            bool isShaderBroken(Shader s) => s == null || s.name == "Hidden/InternalErrorShader";
+
             _targets = _materialList.Where(t => t != null && !isShaderBroken(t.shader)).ToList();
             foreach(Material m in _materialList.Where(t => t != null && isShaderBroken(t.shader)))
                 Debug.LogWarning("Material " + m.name + " has no shader assigned");
+
+            _shaderEditor = null;
         }
 
         private void OnGUI()
@@ -65,35 +82,13 @@ namespace Thry
             _scrollPosition = EditorGUILayout.BeginScrollView(_scrollPosition);
             _showMaterials = EditorGUILayout.Foldout(_showMaterials, "Materials");
             EditorGUI.BeginChangeCheck();
-            if(_showMaterials)
-            {
-                EditorGUILayout.BeginVertical();
-                for (int i = 0; i < _materialList.Count; i++)
-                {
-                    EditorGUILayout.BeginHorizontal();
-                    GUILayout.Space(30);
-                    _materialList[i] = (Material)EditorGUILayout.ObjectField(_materialList[i], typeof(Material), false);
-                    if (GUILayout.Button("Remove", GUILayout.Width(70)))
-                    {
-                        _materialList.RemoveAt(i);
-                    }
-                    EditorGUILayout.EndHorizontal();
-                }
-                EditorGUILayout.BeginHorizontal();
-                GUILayout.Space(30);
-                if (GUILayout.Button("Add", GUILayout.Width(70)))
-                {
-                    _materialList.Add(null);
-                }
-                EditorGUILayout.EndHorizontal();
-                EditorGUILayout.EndVertical();
-            }
+            DrawMaterials();
 
             // Check if targets have changed
             bool didShadersChange = false;
-            foreach(Material m in _materialList)
+            foreach (Material m in _materialList)
             {
-                if(m != null && (!_targetShaders.ContainsKey(m) || _targetShaders[m] != m.shader))
+                if (m != null && (!_targetShaders.ContainsKey(m) || _targetShaders[m] != m.shader))
                 {
                     didShadersChange = true;
                     _targetShaders[m] = m.shader;
@@ -106,66 +101,99 @@ namespace Thry
             }
 
             // Draw shader editor
-            if (_targets.Count > 0)
+            DrawShaderEditor();
+
+            EditorGUILayout.EndScrollView();
+        }
+
+        private void DrawMaterials()
+        {
+            if (!_showMaterials) return;
+
+            using (new EditorGUILayout.VerticalScope(LeftMargin.Value))
             {
-                // Create shader editor
-                if (_shaderEditor == null)
+                for (int i = 0; i < _materialList.Count; i++) DrawMaterial(i);
+
+                using (new EditorGUILayout.HorizontalScope())
                 {
-                    _shaderEditor = new ShaderEditor();
-                    _materialEditor = MaterialEditor.CreateEditor(_targets.ToArray()) as MaterialEditor;
+                    if (GUILayout.Button("Add", GUILayout.Width(100))) _materialList.Add(null);
 
-                    // group targets by shader, take one material per shader
-                    IEnumerable<Material> materialsToSearchProperties = _targets.GroupBy(t => t.shader).Select(g => g.First());
-                    // get properties for each shader
-                    Dictionary<Shader, HashSet<string>> shaderProperties = materialsToSearchProperties.ToDictionary(m => m.shader, m => new HashSet<string>(MaterialEditor.GetMaterialProperties(new UnityEngine.Object[] { m }).Select(p => p.name)));
-                    // get values of dict as string arrays
-                    IEnumerable<string[]> propertiesPerShader = shaderProperties.Values.Select(v => v.ToArray());
-                    // create intersection of all properties
-                    List<string> propertiesOrdered = propertiesPerShader.Aggregate((a, b) => a.Intersect(b).ToArray()).ToList();
-                    // expand the intersection to be a union, but add each property after the occurence of their predecessor
-                    foreach (string[] properties in propertiesPerShader)
-                    {
-                        int index = 0;
-                        foreach (string property in properties)
-                        {
-                            if (!propertiesOrdered.Contains(property))
-                            {
-                                if (index == 0)
-                                    propertiesOrdered.Insert(0, property);
-                                else
-                                    propertiesOrdered.Insert(propertiesOrdered.IndexOf(properties[index - 1]) + 1, property);
-                            }
-                            index++;
-                        }
-                    }
-                    // For each property get all materials, whos shader has this property
-                    Dictionary<string, List<Material>> propertyMaterials = new Dictionary<string, List<Material>>();
-                    foreach (string property in propertiesOrdered)
-                    {
-                        propertyMaterials[property] = _targets.Where(t => shaderProperties[t.shader].Contains(property)).ToList();
-                    }
-                    // Get MaterialProperties of all materials
-                    _materialProperties = propertiesOrdered.Select(p => MaterialEditor.GetMaterialProperty(propertyMaterials[p].ToArray(), p)).ToArray();
+                    GUILayout.FlexibleSpace();
+
+                    if (GUILayout.Button("Remove All", GUILayout.Width(100))) _materialList.Clear();
                 }
+            }
+        }
 
-                // Seperator
-                EditorGUILayout.LabelField("", GUI.skin.horizontalSlider);
+        private void DrawMaterial(int i)
+        {
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                _materialList[i] = (Material)EditorGUILayout.ObjectField(_materialList[i], typeof(Material), false);
 
-                // Cursed but makes it render similar to the inspector
-                
-                EditorGUILayout.BeginHorizontal();
-                EditorGUILayout.Space(30);
-                EditorGUILayout.BeginVertical();
+                if (GUILayout.Button("Remove", GUILayout.Width(100))) _materialList.RemoveAt(i);
+            }
+        }
+
+        private void DrawShaderEditor()
+        {
+            if (_targets.Count == 0) return;
+
+            // Create shader editor
+            CreateShaderEditor();
+
+            // Seperator
+            EditorGUILayout.LabelField("", GUI.skin.horizontalSlider);
+
+            // Cursed but makes it render similar to the inspector
+            using (new EditorGUILayout.VerticalScope(LeftMargin.Value))
+            {
                 bool wideMode = EditorGUIUtility.wideMode;
                 EditorGUIUtility.wideMode = true;
                 _shaderEditor.OnGUI(_materialEditor, _materialProperties);
                 EditorGUIUtility.wideMode = wideMode;
-                EditorGUILayout.EndVertical();
-                EditorGUILayout.EndHorizontal();
-                
             }
+        }
 
-            EditorGUILayout.EndScrollView();
+        private void CreateShaderEditor()
+        {
+            if (_shaderEditor != null) return;
+
+            _shaderEditor = new ShaderEditor();
+            _materialEditor = Editor.CreateEditor(_targets.ToArray()) as MaterialEditor;
+
+            // group targets by shader, take one material per shader
+            IEnumerable<Material> materialsToSearchProperties = _targets.GroupBy(t => t.shader).Select(g => g.First());
+            // get properties for each shader
+            Dictionary<Shader, HashSet<string>> shaderProperties = materialsToSearchProperties.ToDictionary(m => m.shader, m => new HashSet<string>(MaterialEditor.GetMaterialProperties(new UnityEngine.Object[] { m }).Select(p => p.name)));
+            // get values of dict as string arrays
+            IEnumerable<string[]> propertiesPerShader = shaderProperties.Values.Select(v => v.ToArray());
+            // create intersection of all properties
+            List<string> propertiesOrdered = propertiesPerShader.Aggregate((a, b) => a.Intersect(b).ToArray()).ToList();
+            // expand the intersection to be a union, but add each property after the occurence of their predecessor
+            foreach (string[] properties in propertiesPerShader)
+            {
+                int index = 0;
+                foreach (string property in properties)
+                {
+                    if (!propertiesOrdered.Contains(property))
+                    {
+                        if (index == 0)
+                            propertiesOrdered.Insert(0, property);
+                        else
+                            propertiesOrdered.Insert(propertiesOrdered.IndexOf(properties[index - 1]) + 1, property);
+                    }
+                    index++;
+                }
+            }
+            // For each property get all materials, whos shader has this property
+            Dictionary<string, List<Material>> propertyMaterials = new Dictionary<string, List<Material>>();
+            foreach (string property in propertiesOrdered)
+            {
+                propertyMaterials[property] = _targets.Where(t => shaderProperties[t.shader].Contains(property)).ToList();
+            }
+            // Get MaterialProperties of all materials
+            _materialProperties = propertiesOrdered.Select(p => MaterialEditor.GetMaterialProperty(propertyMaterials[p].ToArray(), p)).ToArray();
         }
     }
 }

--- a/Editor/CrossEditor.cs
+++ b/Editor/CrossEditor.cs
@@ -34,7 +34,7 @@ namespace Thry
         [MenuItem("Assets/Thry/Materials/Add to Cross Shader Editor", true, 400)]
         private static bool OpenInCrossShaderEditorValidation()
         {
-            return Selection.objects.Any(o => o is Material) || ShaderOptimizer.GetSelectedFolders().Count() > 0;
+            return Selection.objects.Any(o => o is Material) || ShaderOptimizer.GetSelectedFolders().Any();
         }
 
         [MenuItem("GameObject/Thry/Materials/Open All in Cross Shader Editor", false, 10)]

--- a/Editor/CrossEditor.cs
+++ b/Editor/CrossEditor.cs
@@ -76,36 +76,33 @@ namespace Thry
 
         private void OnGUI()
         {
-            // List of materials, remove button next to each
-            // Add button at bottom
-
             _scrollPosition = EditorGUILayout.BeginScrollView(_scrollPosition);
             _showMaterials = EditorGUILayout.Foldout(_showMaterials, "Materials");
+
             EditorGUI.BeginChangeCheck();
             DrawMaterials();
 
             // Check if targets have changed
-            bool didShadersChange = false;
+            bool didShadersChange = EditorGUI.EndChangeCheck();
             foreach (Material m in _materialList)
             {
-                if (m != null && (!_targetShaders.ContainsKey(m) || _targetShaders[m] != m.shader))
-                {
-                    didShadersChange = true;
-                    _targetShaders[m] = m.shader;
-                }
-            }
-            if (EditorGUI.EndChangeCheck() || didShadersChange)
-            {
-                _shaderEditor = null;
-                UpdateTargets();
+                if (m == null || // Material is null
+                    _targetShaders.ContainsKey(m) && _targetShaders[m] == m.shader) // Shader hasn't changed
+                    continue;
+
+                didShadersChange = true;
+                _targetShaders[m] = m.shader;
             }
 
-            // Draw shader editor
+            if (didShadersChange) UpdateTargets();
+
             DrawShaderEditor();
 
             EditorGUILayout.EndScrollView();
         }
 
+        // List of materials, remove button next to each
+        // Add and Remove All buttons at bottom
         private void DrawMaterials()
         {
             if (!_showMaterials) return;
@@ -129,7 +126,14 @@ namespace Thry
         {
             using (new EditorGUILayout.HorizontalScope())
             {
-                _materialList[i] = (Material)EditorGUILayout.ObjectField(_materialList[i], typeof(Material), false);
+                Material material = (Material)EditorGUILayout.ObjectField(_materialList[i], typeof(Material), false);
+
+                if (material != _materialList[i])
+                {
+                    if (_materialList.Contains(material)) material = null;
+
+                    _materialList[i] = material;
+                }
 
                 if (GUILayout.Button("Remove", GUILayout.Width(100))) _materialList.RemoveAt(i);
             }

--- a/Editor/ShaderOptimizer.cs
+++ b/Editor/ShaderOptimizer.cs
@@ -2064,7 +2064,7 @@ namespace Thry
         [MenuItem("Assets/Thry/Materials/Lock Folder", true)]
         static bool LockFolderValidator()
         {
-            return GetSelectedFolders().Count() > 0;
+            return GetSelectedFolders().Any();
         }
 
         //-----Folder Unlock
@@ -2077,7 +2077,7 @@ namespace Thry
         [MenuItem("Assets/Thry/Materials/Unlock Folder", true)]
         static bool UnLockFolderValidator()
         {
-            return GetSelectedFolders().Count() > 0;
+            return GetSelectedFolders().Any();
         }
 
         //----Folder Unlock


### PR DESCRIPTION
- Extracted ShaderOptimizer selected folder logic to new method.
- Extracted/refactored ShaderOptimizer material lookup to new methods.
- "Thry/Materials/Lock Folder" and "Thry/Materials/Unlock Folder" can now operate when a selection contains folders, but is not entirely comprised of folders.
- Various cleanup and refactoring for CrossEditor.
- Added "Remove All" button to material list in CrossEditor.
- "Thry/Materials/Open in Cross Shader Editor" has been renamed to "Thry/Materials/Add to Cross Shader Editor" and the behavior has changed accordingly.
- "Thry/Materials/Add to Cross Shader Editor" now supports folders (fixes #87).
- The same material can no longer be added multiple times to CrossEditor.