### PR TITLE
Fix #121

### DIFF
--- a/Editor/EditorStructs/ShaderPart.cs
+++ b/Editor/EditorStructs/ShaderPart.cs
@@ -1025,7 +1025,7 @@ namespace Thry
 
         object ClipToKeyFrame(Type animationCurveType, AnimationClip clip, string path, string propertyPostFix, Type rendererType)
         {
-            FieldInfo curvesField = animationCurveType.GetField("m_Keyframes", BindingFlags.Instance | BindingFlags.Public);
+            FieldInfo curvesField = animationCurveType.GetField("m_Keyframes", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
 
             object windowCurve = Activator.CreateInstance(animationCurveType, clip,
                 EditorCurveBinding.FloatCurve(path, rendererType, "material." + GetAnimatedPropertyName() + propertyPostFix), typeof(float));


### PR DESCRIPTION
Unity 2022.3.8f turned `m_Keyframes` private ([ref](https://github.com/Unity-Technologies/UnityCsReference/blob/dd670d2a7455b699a4b73d53a3a198131deb2323/Editor/Mono/Animation/AnimationWindow/AnimationWindowCurve.cs#L18)), the reflection field lookup only searched for public fields, this is now corrected.