### PR TITLE
Removed the useless Unity 2019/2022 check when getting stripped assets' GUIDs while locking the shader.

### DIFF
--- a/Editor/ShaderOptimizer.cs
+++ b/Editor/ShaderOptimizer.cs
@@ -1501,13 +1501,7 @@ namespace Thry.ThryEditor
                 {
                     if(doStrip)
                     {
-                        var guid =
-#if UNITY_2019_1_OR_NEWER
-                        AssetDatabase.AssetPathToGUID(AssetDatabase.GetAssetPath(material.GetTexture(propName)));
-#elif UNITY_2022_1_OR_NEWER
-                        AssetDatabase.GUIDFromAssetPath(AssetDatabase.GetAssetPath(material.GetTexture(propName)));
-#endif
-                        savedTextures.Add(("_stripped_tex_" + propName, guid.ToString()));
+                        savedTextures.Add(("_stripped_tex_" + propName, AssetDatabase.AssetPathToGUID(AssetDatabase.GetAssetPath(material.GetTexture(propName)))));
                     }
                     serializedTexProperties.DeleteArrayElementAtIndex(i);
                     i -= 1;


### PR DESCRIPTION
Hi,
if we're using Unity 2022, when compiling the current code, the "#if UNITY_2019_1_OR_NEWER" check passes, and it never gets to checking the "#elif UNITY_2022_1_OR_NEWER". They are supposed to be the other way around.

I thought about just switching them around, but
- AssetPathToGUID exists in U2022 as well, so there's no need to avoid it (well, obviously, because it gets executed in U2022 right now anyway and it doesn't crash),
- GUIDFromAssetPath returns a GUID object that is later `.ToString()`ed (which is what happens internally in AssetPathToGUID),
- AssetPathToGUID returns a string that... is then `.ToString()`ed as well pointlessly.

Also, currently if you were to use Unity earlier than 2019, the script would just not compile, which is not good. It probably won't really be used there and may not compile/may crash for other reasons anyway, but hey, that's one additional unnecessary reason to do that. :)

I decided that it just makes more sense to skip the checks and use AssetPathToGUID in all cases.