### PR TITLE
Tagged Material Properties support Light Theme

### DIFF
--- a/Editor/Styles.cs
+++ b/Editor/Styles.cs
@@ -19,8 +19,8 @@ namespace Thry.ThryEditor
             contentOffset = new Vector2(20f, -2f)
         };
 
-        public static readonly GUIStyle animatedIndicatorStyle = new GUIStyle() { normal = new GUIStyleState() { textColor = new Color(0.3f, 1, 0.3f) }, alignment = TextAnchor.MiddleRight };
-        public static readonly GUIStyle presetIndicatorStyle = new GUIStyle() { normal = new GUIStyleState() { textColor = Color.cyan }, alignment = TextAnchor.MiddleRight };
+        public static readonly GUIStyle animatedIndicatorStyle = new GUIStyle() { normal = new GUIStyleState() { textColor = EditorGUIUtility.isProSkin ? new Color(0.3f, 1f, 0.3f) : new Color(0f, 0.5f, 0f) }, alignment = TextAnchor.MiddleRight };
+        public static readonly GUIStyle presetIndicatorStyle = new GUIStyle() { normal = new GUIStyleState() { textColor = EditorGUIUtility.isProSkin ? new Color(0f, 1f, 1f) : new Color(0f, 0.5f, 0.71f) }, alignment = TextAnchor.MiddleRight };
         public static readonly GUIStyle madeByLabel = new GUIStyle(EditorStyles.label) { fontSize = 10 };
         public static readonly GUIStyle notification = new GUIStyle(GUI.skin.box) { fontSize = 12, wordWrap = true, normal = new GUIStyleState() { textColor = Color.red } };
         public static GUIStyle label_property_note { get; private set; } = new GUIStyle(EditorStyles.label)


### PR DESCRIPTION
Added a rule in `Styles.cs` to ensure Material Properties tagged with `A` or `RA` are easier to see on the Unity Light Theme, ensuring the text color are updated correctly based on what `EditorGUIUtility.isProSkin` value is currently broadcasting.

Additionally, this rule was also added to ensure Preset properties (tagged with `P`) are easier to see as well.