### PR TITLE
Suppress exceptions during lock/unlock

### DIFF
--- a/Editor/Drawers/ThryMultiFloats.cs
+++ b/Editor/Drawers/ThryMultiFloats.cs
@@ -34,7 +34,14 @@ namespace Thry.ThryEditor.Drawers
 
             for (int i = 0; i < _otherProperties.Length; i++)
             {
-                var sProp = ShaderEditor.Active.PropertyDictionary[_otherProperties[i]];
+                if (!ShaderEditor.Active.PropertyDictionary.TryGetValue(_otherProperties[i], out var sProp))
+                {
+                    // TODO: log error?
+                    _otherMaterialProps[i] = null;
+
+                    continue;
+                }
+
                 sProp.UpdatedMaterialPropertyReference();
                 _otherMaterialProps[i] = sProp.MaterialProperty;
             }
@@ -48,8 +55,11 @@ namespace Thry.ThryEditor.Drawers
                 {
                     PropGUI(prop, editor, contentR, 0);
                     editor.EndAnimatedCheck();
-                    for (int i = 0; i < _otherProperties.Length; i++)
+                    for (int i = 0; i < _otherMaterialProps.Length; i++)
                     {
+                        if (_otherMaterialProps[i] == null)
+                            continue;
+
                         PropGUI(_otherMaterialProps[i], editor, contentR, i + 1);
                     }
                     editor.BeginAnimatedCheck(prop);
@@ -66,14 +76,17 @@ namespace Thry.ThryEditor.Drawers
             bool animated = ShaderEditor.Active.CurrentProperty.IsAnimated;
             bool renamed = ShaderEditor.Active.CurrentProperty.IsRenaming;
             for (int i = 0; i < _otherProperties.Length; i++)
-                ShaderEditor.Active.PropertyDictionary[_otherProperties[i]].SetAnimated(animated, renamed);
+            {
+                if (ShaderEditor.Active.PropertyDictionary.TryGetValue(_otherProperties[i], out var sProp))
+                    sProp.SetAnimated(animated, renamed);
+            }
         }
 
         void PropGUI(MaterialProperty prop, MaterialEditor editor, Rect contentRect, int index)
         {
             contentRect.x += contentRect.width * index;
             contentRect.width -= 5;
-            
+
             using (new GUILib.AnimationScope(editor, prop))
             {
                 using(var change_scope = new EditorGUI.ChangeCheckScope())

--- a/Editor/EditorStructs/OtherShaderProperties.cs
+++ b/Editor/EditorStructs/OtherShaderProperties.cs
@@ -132,7 +132,17 @@ namespace Thry.ThryEditor
 
         protected override void DrawDefault()
         {
-            MyShaderUI.Editor.EnableInstancingField();
+            // internal reference is stored within MaterialEditor.m_Shader and can be null during lock/unlock
+            // MyShaderUI.Editor.serializedObject.FindProperty("m_Shader").objectReferenceValue
+            // never failed a null check in my tests, so try/catch it is - Dor
+            
+            try
+            {
+                MyShaderUI.Editor.EnableInstancingField();
+            }
+            catch (ArgumentNullException) // internal shader reference was null
+            {
+            }
         }
     }
     public class GIProperty : ShaderProperty


### PR DESCRIPTION
These exceptions, to my knowledge, only happen for one frame during lock/unlock.