### PR TITLE
Added math to accommodate Notes. Fixes #154

### DIFF
--- a/Editor/EditorStructs/ShaderHeader.cs
+++ b/Editor/EditorStructs/ShaderHeader.cs
@@ -91,13 +91,15 @@ namespace Thry.ThryEditor
                         ShaderEditor.Active.Locale.Set(MaterialProperty.name, newTranslation);
                         ShaderEditor.Active.Locale.Save();
                     }
-                }else
+                }
+                else
                 {
                     GUI.Box(rect, new GUIContent("     " + content.text, content.tooltip), Styles.dropdownHeader);
-                    if(Config.Instance.showNotes && !string.IsNullOrWhiteSpace(Note))
+                    if (Config.Instance.showNotes && !string.IsNullOrWhiteSpace(Note))
                     {
                         Rect noteRect = new Rect(rect);
-                        noteRect.width -= 60;
+                        float reserved = NotesHelper.GetPackedRightReservation(rect, options, this.MaterialProperty.name, Styles.label_property_note);
+                        noteRect.width = Mathf.Max(0f, noteRect.width - reserved);
                         GUI.Label(noteRect, Note, Styles.label_property_note);
                     }
                 }
@@ -132,7 +134,8 @@ namespace Thry.ThryEditor
                 if(Config.Instance.showNotes && !string.IsNullOrWhiteSpace(Note))
                 {
                     Rect noteRect = new Rect(rect);
-                    noteRect.width -= 60;
+                    float reserved = NotesHelper.GetPackedRightReservation(rect, options, this.MaterialProperty.name, Styles.label_property_note);
+                    noteRect.width = Mathf.Max(0f, noteRect.width - reserved);
                     GUI.Label(noteRect, Note, Styles.label_property_note);
                 }
                 DrawIcons(rect, options, e);

--- a/Editor/Helpers/NotesHelper.cs
+++ b/Editor/Helpers/NotesHelper.cs
@@ -1,0 +1,49 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace Thry.ThryEditor.Helpers
+{
+    public static class NotesHelper
+    {
+        /// <summary>
+        /// This script computes how much width (in pixels) to reserve on the right side of a header 
+        /// so that the Notes label doesn't overlap the packed icon row and the author badge (if provided). 
+        /// Mirrors current DrawIcons packing: (menu, link, help, presets, author)
+        /// </summary>
+        public static float GetPackedRightReservation(Rect rect, PropertyOptions options, string sectionPropertyName, GUIStyle authorLabelStyle = null, float iconGap = 2f, float safetyPad = 2f)
+        {
+            // Match icon sizing as DrawIcons
+            float iconSize = Mathf.Max(0f, rect.height - 4f);
+            float step = iconSize + iconGap;
+
+            // Always: menu, link
+            int count = 0;
+            count += 2;
+
+            bool hasHelp = options?.button_help != null && options.button_help.condition_show.Test();
+            bool hasPresets = Presets.DoesSectionHavePresets(sectionPropertyName);
+            bool hasAuthor = options?.button_author != null && options.button_author.condition_show.Test();
+
+            if (hasHelp) count++;
+            if (hasPresets) count++;
+            if (hasAuthor) count++;
+
+            float reserved = count * step;
+
+            // Calculates dynamic width to accommodate author text badge if it exists
+            if (hasAuthor)
+            {
+                string authorText = options.button_author.text ?? string.Empty;
+                if (authorText.Length > 0)
+                {
+                    GUIStyle labelStyle = Styles.label_property_note;
+                    Vector2 textSize = labelStyle.CalcSize(new GUIContent(authorText));
+                    float labelPad = 2f;
+                    reserved += textSize.x + labelPad;
+                }
+            }
+
+            return reserved + safetyPad;
+        }
+    }
+}

--- a/Editor/Helpers/NotesHelper.cs.meta
+++ b/Editor/Helpers/NotesHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 35ef7a5bc0160674d88e380745ed5986
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
By using the math in NotesHelper, this helps ensure that rendering Notes never overlap icons or text drawn on the ShaderHeader.