### PR TITLE
Fixed ChilloutVR External hooks

### DIFF
--- a/External/Editor/AbiAutoAnchor.cs
+++ b/External/Editor/AbiAutoAnchor.cs
@@ -1,8 +1,9 @@
 #if CVR_CCK_EXISTS
 using System;
+using System.Reflection;
 using UnityEngine;
 using UnityEditor;
-using ABI.CCK.Scripts.Editor;
+using UnityEngine.Events;
 
 namespace Thry.ThryEditor.UploadCallbacks // sry Pumkin for taking away your namespace. Just tring to tidy up a bit
 {
@@ -11,10 +12,24 @@ namespace Thry.ThryEditor.UploadCallbacks // sry Pumkin for taking away your nam
     {
         static AbiAutoAnchor()
         {
-            CCK_BuildUtility.PreAvatarBundleEvent.AddListener(OnPreBundleEvent);
+            try
+            {
+                // CCK_BuildUtility.PreAvatarBundleEvent.AddListener(OnPreBundleEvent);
+                Type type = Assembly.Load("Assembly-CSharp-Editor").GetType("ABI.CCK.Scripts.Editor.CCK_BuildUtility");
+                FieldInfo preAvatarBundleEvent = type.GetField("PreAvatarBundleEvent", BindingFlags.Static | BindingFlags.Public);
+                MethodInfo method = typeof(UnityEvent<GameObject>).GetMethod("AddListener");
+                MethodInfo methodOnBuild = typeof(AbiAutoAnchor).GetMethod(nameof(OnPreBundleEvent), BindingFlags.Static | BindingFlags.NonPublic);
+                UnityAction<GameObject> m = (UnityAction<GameObject>)Delegate.CreateDelegate(typeof(UnityAction<GameObject>), null, methodOnBuild!);
+                method!.Invoke(preAvatarBundleEvent!.GetValue(null), new object[]{m});
+            }
+            catch(Exception e)
+            {
+                Debug.LogError("Failed to hook to ChilloutVR pre-build events, the auto-anchor won't work for ChilloutVR.");
+                Debug.LogException(e);
+            }
         }
 
-        static void OnPreBundleEvent(GameObject uploadedObject)
+        private static void OnPreBundleEvent(GameObject uploadedObject)
         {
             try
             {

--- a/External/Editor/AbiAutoLock.cs
+++ b/External/Editor/AbiAutoLock.cs
@@ -1,12 +1,13 @@
 ﻿#if CVR_CCK_EXISTS
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using ABI.CCK.Scripts.Editor;
-using ABI.CCK.Components;
 using UnityEditor;
 using System.Linq;
+using System.Reflection;
 using Thry.ThryEditor.Helpers;
+using UnityEngine.Events;
 
 namespace Thry.ThryEditor.UploadCallbacks
 {
@@ -15,25 +16,61 @@ namespace Thry.ThryEditor.UploadCallbacks
         [InitializeOnLoad]
         public class CVR_UploadLocking
         {
+            private static readonly Type CVRAvatarType;
+            private static FieldInfo _cvrAvatarOverridesField;
+
             static CVR_UploadLocking()
             {
-                CCK_BuildUtility.PreAvatarBundleEvent.AddListener(OnPreBundleEvent);
-                CCK_BuildUtility.PrePropBundleEvent.AddListener(OnPreBundleEvent);
+
+                try
+                {
+
+                    // CCK_BuildUtility.PreAvatarBundleEvent.AddListener(OnPreBundleEvent);
+                    // CCK_BuildUtility.PrePropBundleEvent.AddListener(OnPreBundleEvent);
+                    Assembly assemblyEditor = Assembly.Load("Assembly-CSharp-Editor");
+                    Type type = assemblyEditor.GetType("ABI.CCK.Scripts.Editor.CCK_BuildUtility");
+                    FieldInfo preAvatarBundleEvent = type.GetField("PreAvatarBundleEvent", BindingFlags.Static | BindingFlags.Public);
+                    FieldInfo prePropBundleEvent = type.GetField("PrePropBundleEvent", BindingFlags.Static | BindingFlags.Public);
+                    MethodInfo method = typeof(UnityEvent<GameObject>).GetMethod("AddListener");
+                    MethodInfo methodOnBuild = typeof(CVR_UploadLocking).GetMethod(nameof(OnPreBundleEvent), BindingFlags.Static | BindingFlags.NonPublic);
+                    UnityAction<GameObject> m = (UnityAction<GameObject>)Delegate.CreateDelegate(typeof(UnityAction<GameObject>), null, methodOnBuild!);
+                    method!.Invoke(preAvatarBundleEvent!.GetValue(null), new object[]{m});
+                    method.Invoke(prePropBundleEvent!.GetValue(null), new object[]{m});
+
+                    Assembly assembly = Assembly.Load("Assembly-CSharp");
+                    CVRAvatarType = assembly.GetType("ABI.CCK.Components.CVRAvatar");
+                    _cvrAvatarOverridesField = CVRAvatarType.GetField("overrides", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                }
+                catch(Exception e)
+                {
+                    Debug.LogError("Failed to hook to ChilloutVR pre-build events, the material auto-lock won't work for ChilloutVR.");
+                    Debug.LogException(e);
+                }
             }
 
-            static void OnPreBundleEvent(GameObject uploadedObject)
+            private static void OnPreBundleEvent(GameObject uploadedObject)
             {
                 List<Material> materials = new List<Material>();
-                CVRAvatar descriptor = uploadedObject.GetComponent<CVRAvatar>();
+                // CVRAvatar descriptor = uploadedObject.GetComponent<CVRAvatar>();
+                Component descriptor = uploadedObject.GetComponent(CVRAvatarType);
 
                 // All renderers
                 materials.AddRange(uploadedObject.GetComponentsInChildren<Renderer>(true).SelectMany(r => r.sharedMaterials));
-                
+
                 // Find animation clips
                 IEnumerable<AnimationClip> clips = uploadedObject.GetComponentsInChildren<Animator>(true).Where(a => a != null && a.runtimeAnimatorController != null).
                     Select(a => a.runtimeAnimatorController).SelectMany(a => a.animationClips);
-                if (descriptor != null && descriptor.overrides != null)
-                    clips = clips.Concat(descriptor.overrides.animationClips);
+
+                // if (descriptor != null && descriptor.overrides != null)
+                //     clips = clips.Concat(descriptor.overrides.animationClips);
+                if (descriptor != null)
+                {
+                    var overrideController = _cvrAvatarOverridesField.GetValue(descriptor) as AnimatorOverrideController;
+                    if (overrideController != null)
+                    {
+                        clips = clips.Concat(overrideController.animationClips);
+                    }
+                }
 
                 // Hanlde clips
                 clips = clips.Distinct().Where(c => c != null);
@@ -45,7 +82,7 @@ namespace Thry.ThryEditor.UploadCallbacks
                 }
 
                 materials = materials.Distinct().ToList();
-                ShaderOptimizer.SetLockedForAllMaterials(materials, 1, showProgressbar: true, showDialog: PersistentData.Get<bool>("ShowLockInDialog", true), allowCancel: false);
+                ShaderOptimizer.LockMaterials(materials);
             }
         }
     }


### PR DESCRIPTION
ChilloutVR doesn't have an assembly definition.
And since the External stuff is now inside of one, we need to use reflection to access the hooks.