### PR TITLE
Fixed Gradient Texture Data Loss, Added Safeguards

### DIFF
--- a/Editor/Config.cs
+++ b/Editor/Config.cs
@@ -11,7 +11,7 @@ namespace Thry.ThryEditor
     public class Config
     {
         private const string PATH_CONFIG_FILE = "Thry/Config.json";
-        private static readonly Version INSTALLED_VERSION = "2.69.3";
+        private static readonly Version INSTALLED_VERSION = "2.69.4";
 
         private static Config s_config;
 

--- a/Editor/GradiantEditor.cs
+++ b/Editor/GradiantEditor.cs
@@ -85,6 +85,8 @@ namespace Thry.ThryEditor
 
         public void OnDestroy()
         {
+            GradientPreviewManager.ClearPreview(_prop);
+            
             if (_gradient_has_been_edited)
             {
                 if (_data.PreviewTexture.GetType() == typeof(Texture2D))
@@ -237,6 +239,8 @@ namespace Thry.ThryEditor
 
         private new void DiscardChanges()
         {
+            GradientPreviewManager.ClearPreview(_prop);
+            _data.UsePreviewTexture = false;
             _prop.textureValue = _privious_preview_texture;
             SetGradient(TextureHelper.GetGradient(_privious_preview_texture), generatePreviewTexture: false);
             _gradient_has_been_edited = false;
@@ -259,13 +263,17 @@ namespace Thry.ThryEditor
         private void UpdateGradientPreviewTexture()
         {
             _data.PreviewTexture = Converter.GradientToTexture(_data.Gradient, textureSettings.width, textureSettings.height);
+
+            _data.PreviewTexture.hideFlags = HideFlags.HideAndDontSave;
+
             textureSettings.ApplyModes(_data.PreviewTexture);
 
-            // IMPORTANT: DO NOT assign _prop.textureValue here!
-            // The drawer already knows how to show a Preview Texture when UsePreviewTexture is set to true.
             _data.UsePreviewTexture = true;
-
             _gradient_has_been_edited = true;
+
+            // Instead of assigning a Prop Texture, create a temporary texture for a live preview.
+            GradientPreviewManager.ApplyPreview(_prop, _data.PreviewTexture);
+
             ShaderEditor.RepaintActive();
         }
 

--- a/Editor/GradiantEditor.cs
+++ b/Editor/GradiantEditor.cs
@@ -85,8 +85,9 @@ namespace Thry.ThryEditor
 
         public void OnDestroy()
         {
+            // Ensure the live-preview of the gradient texture is not leftover when this window closes.
             GradientPreviewManager.ClearPreview(_prop);
-            
+
             if (_gradient_has_been_edited)
             {
                 if (_data.PreviewTexture.GetType() == typeof(Texture2D))

--- a/Editor/Helpers/GradientPreviewManager.cs
+++ b/Editor/Helpers/GradientPreviewManager.cs
@@ -1,0 +1,127 @@
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+namespace Thry.ThryEditor.Helpers
+{
+    [InitializeOnLoad]
+    internal static class GradientPreviewManager
+    {
+        private struct Key
+        {
+            public int materialId;
+            public string propName;
+            public Key(int id, string prop)
+            {
+                materialId = id;
+                propName = prop;
+            }
+        }
+
+        private class Entry
+        {
+            public Material mat;
+            public string propName;
+            public Texture original;
+            public Texture preview;
+        }
+
+        private static readonly Dictionary<Key, Entry> _entries = new Dictionary<Key, Entry>();
+        private static bool _restoredForSave;
+
+        static GradientPreviewManager()
+        {
+            AssemblyReloadEvents.beforeAssemblyReload += RestoreAll;
+            EditorApplication.quitting += RestoreAll;
+            EditorApplication.playModeStateChanged += s =>
+            {
+                if (s == PlayModeStateChange.ExitingEditMode || s == PlayModeStateChange.ExitingPlayMode) RestoreAll();
+            };
+        }
+
+        internal static void ApplyPreview(MaterialProperty prop, Texture previewTex)
+        {
+            if (prop == null || previewTex == null) return;
+
+            foreach (Object o in prop.targets)
+            {
+                var mat = o as Material;
+                if (mat == null) continue;
+
+                var key = new Key(mat.GetInstanceID(), prop.name);
+                if (!_entries.TryGetValue(key, out var entry))
+                {
+                    entry = new Entry
+                    {
+                        mat = mat,
+                        propName = prop.name,
+                        original = mat.GetTexture(prop.name),
+                        preview = previewTex
+                    };
+                    _entries.Add(key, entry);
+                }
+                else
+                {
+                    entry.preview = previewTex;
+                }
+
+                mat.SetTexture(prop.name, previewTex);
+            }
+        }
+
+        internal static void ClearPreview(MaterialProperty prop)
+        {
+            if (prop == null) return;
+
+            foreach (Object o in prop.targets)
+            {
+                var mat = o as Material;
+                if (mat == null) continue;
+
+                var key = new Key(mat.GetInstanceID(), prop.name);
+                if (_entries.TryGetValue(key, out var entry))
+                {
+                    if (entry.mat != null) entry.mat.SetTexture(entry.propName, entry.original);
+
+                    _entries.Remove(key);
+                }
+            }
+        }
+
+        internal static void BeforeSaveRestoreOriginals()
+        {
+            if (_entries.Count == 0) return;
+
+            foreach (var kv in _entries)
+            {
+                var e = kv.Value;
+                if (e.mat != null) e.mat.SetTexture(e.propName, e.original);
+            }
+
+            _restoredForSave = true;
+        }
+
+        internal static void AfterSaveReapplyPreviews()
+        {
+            if (!_restoredForSave) return;
+            _restoredForSave = false;
+
+            foreach (var kv in _entries)
+            {
+                var e = kv.Value;
+                if (e.mat != null && e.preview != null) e.mat.SetTexture(e.propName, e.preview);
+            }
+        }
+
+        internal static void RestoreAll()
+        {
+            foreach (var kv in _entries)
+            {
+                var e = kv.Value;
+                if (e.mat != null) e.mat.SetTexture(e.propName, e.original);
+            }
+            _entries.Clear();
+            _restoredForSave = false;
+        }
+    }
+}

--- a/Editor/Helpers/GradientPreviewManager.cs.meta
+++ b/Editor/Helpers/GradientPreviewManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 77138b121d752754595c6acc4670d322
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Helpers/GradientPreviewSafeguard.cs
+++ b/Editor/Helpers/GradientPreviewSafeguard.cs
@@ -1,0 +1,14 @@
+using UnityEditor;
+
+namespace Thry.ThryEditor.Helpers
+{
+    internal class GradientPreviewSafeguard : AssetModificationProcessor
+    {
+        private static string[] OnWillSaveAssets(string[] paths)
+        {
+            GradientPreviewManager.BeforeSaveRestoreOriginals();
+            EditorApplication.delayCall += GradientPreviewManager.AfterSaveReapplyPreviews;
+            return paths;
+        }
+    }
+}

--- a/Editor/Helpers/GradientPreviewSafeguard.cs.meta
+++ b/Editor/Helpers/GradientPreviewSafeguard.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: df01e590c0b4f72479ab77527061c04b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This is an important change for the Gradient Editor script. I've found that using the Gradient Editor (especially when using Texture Ramp shading) that data is lost to oblivion in some cases, especially on Repaint. I have fixed this bug, alongside some data-preserving safeguards I've added to ensure this never happens again.

**Also, the Gradient Editor should now correctly fetch and retain original data from the gradient when editing.** This fixes a long-standing bug where the gradient data is slightly altered each time the Gradient Editor is opened.

_This PR mandates a patch version bump!_

For more information, see comments I've left on significant lines of code I changed.

### List of Changes

- Updated Gradient Editor to fetch, retain, and write data more accurately. This makes the Gradient Editor far more reliable than before.
- Fixed a long-standing bug where Gradient data is slightly altered each time the Gradient Editor is opened from a Gradient Texture Slot.
- Fixed an uncommon bug where Gradients would be lost on Repaint.
- Added Gradient Preview Manager Helper Script to fully manage how editing Gradients are previewed in real time. It is used by the main Gradient Editor.
- Added a Safeguard Helper to ensure data loss never occurs.
- Added and surrounded two additional texture importer settings for gradients with an `#if VRC_SDK_VRCSDK3` statement to enforce Mipmap Streaming (for SDK uploads) and Kaiser filtering (for VRChat's DPID algorithm).
- Bumped patch version number.