### PR TITLE
Fix non-default indicator (*) and Reset for multi-property drawers

### DIFF
--- a/Editor/Drawers/ThryMultiFloats.cs
+++ b/Editor/Drawers/ThryMultiFloats.cs
@@ -107,6 +107,17 @@ namespace Thry.ThryEditor.Drawers
         public override float GetPropertyHeight(MaterialProperty prop, string label, MaterialEditor editor)
         {
             ShaderProperty.RegisterDrawer(this);
+            
+            // Register additional properties for default value checking (for the * indicator feature)
+            // Must be done here (not in OnGUI) because Content is accessed before OnGUI runs
+            if (ShaderEditor.Active?.PropertyDictionary != null)
+            {
+                if (ShaderEditor.Active.PropertyDictionary.TryGetValue(prop.name, out var mainShaderProp))
+                {
+                    mainShaderProp.AdditionalDefaultCheckProperties = _otherProperties;
+                }
+            }
+            
             return base.GetPropertyHeight(prop, label, editor);
         }
     }


### PR DESCRIPTION
- Add AdditionalDefaultCheckProperties to ShaderPart for multi-property drawers
- IsPropertyValueDefault now checks additional properties when determining if value is default
- ResetMaterialProperties now resets all additional properties
- ThryMultiFloats registers its other properties for proper default checking

This fixes the asterisk (*) indicator only appearing when the first property changes, and ensures Reset from context menu resets all properties in multi-float controls.