### PR TITLE
Redesigned Localization for new format + Remote Spreadsheet Sync

### DIFF
--- a/Editor/Localization.cs
+++ b/Editor/Localization.cs
@@ -556,7 +556,7 @@ namespace Thry.ThryEditor
             static bool ShouldIgnoreKey(string key)
             {
                 if (string.IsNullOrEmpty(key)) return false;
-                return key.StartsWith("s_end_", StringComparison.Ordinal) || key.StartsWith("m_end_", StringComparison.Ordinal);
+                return key.StartsWith("s_end_", StringComparison.Ordinal) || key.StartsWith("m_end_", StringComparison.Ordinal) || key.StartsWith("ss_end_", StringComparison.Ordinal);
             }
 
             void ExportAsCSV(Localization locale)

--- a/Editor/Localization.cs
+++ b/Editor/Localization.cs
@@ -595,43 +595,6 @@ namespace Thry.ThryEditor
                 }
             }
 
-            // DEBUG FUNCTION: Export a CSV File only with Properties that don't currently exist in Localization.
-            void ExportMissingAsCSV(Localization locale)
-            {
-                locale.Load();
-                UpdateData(locale);
-
-                HashSet<string> existing = new HashSet<string>();
-                if (locale._keys != null) foreach (var k in locale._keys) if (!string.IsNullOrEmpty(k)) existing.Add(k);
-
-                string path = EditorUtility.SaveFilePanel("Debug: Export Missing Properties as CSV", "", locale.name + "_Missing", "csv");
-                if (string.IsNullOrEmpty(path)) return;
-
-                System.Text.StringBuilder sb = new System.Text.StringBuilder();
-
-                sb.Append(ToCSVString("Property"));
-                sb.Append("," + ToCSVString("English"));
-                foreach (string language in locale.Languages) sb.Append("," + ToCSVString(language));
-                sb.AppendLine();
-
-                foreach (var kvp in _defaultPropertyContent)
-                {
-                    string key = kvp.Key;
-                    if (ShouldIgnoreKey(key)) continue;
-                    if (existing.Contains(key)) continue;
-
-                    string english = kvp.Value ?? "";
-                    sb.Append(ToCSVString(key));
-                    sb.Append("," + ToCSVString(english));
-
-                    for (int j = 0; j < locale.Languages.Length; j++) sb.Append(",");
-
-                    sb.AppendLine();
-                }
-
-                File.WriteAllText(path, sb.ToString(), new System.Text.UTF8Encoding(true));
-            }
-
             void LoadFromCSV(Localization locale)
             {
                 string path = EditorUtility.OpenFilePanel("Load from CSV", "", "csv");
@@ -876,8 +839,6 @@ namespace Thry.ThryEditor
                 }
 
                 if (GUILayout.Button("Export as CSV")) ExportAsCSV(locale);
-
-                if (GUILayout.Button("Export Missing Properties as CSV")) ExportMissingAsCSV(locale);
 
                 EditorGUILayout.Space();
 

--- a/Editor/Localization.cs
+++ b/Editor/Localization.cs
@@ -257,6 +257,12 @@ namespace Thry.ThryEditor
             return Selection.activeObject is Localization;
         }
 
+        static bool ShouldIgnoreKey(string key)
+        {
+            if (string.IsNullOrEmpty(key)) return false;
+            return key.StartsWith("s_end_", StringComparison.Ordinal) || key.StartsWith("m_end_", StringComparison.Ordinal);
+        }
+
         [CustomEditor(typeof(Localization))]
         public class LocaleEditor : Editor
         {
@@ -341,6 +347,7 @@ namespace Thry.ThryEditor
                     for (int i = 0; i < locale._keys.Length; i++)
                     {
                         string key = locale._keys[i];
+                        if (ShouldIgnoreKey(key)) continue;
                         sb.Append(ToCSVString(key));
 
                         // Column 2: UI Label as written in the shader (MaterialProperty.displayName)

--- a/Editor/Localization.cs
+++ b/Editor/Localization.cs
@@ -743,6 +743,8 @@ namespace Thry.ThryEditor
                 EditorGUILayout.Space(20);
                 EditorGUILayout.LabelField("", GUI.skin.horizontalSlider);
                 EditorGUILayout.LabelField("Import / Export", EditorStyles.boldLabel);
+                EditorGUILayout.HelpBox("Use this area to load Localization data from an external CSV file locally, then click Import. Optionally, you can load data from the internet via a valid URL.", MessageType.Info);
+                EditorGUILayout.HelpBox("DO NOT USE COMMAS in translated text! Commas will break formatting by leaking text into other languages!", MessageType.Warning);
                 GUICSV(locale);
 
                 if (locale.Languages.Length == 0)
@@ -775,7 +777,7 @@ namespace Thry.ThryEditor
                 EditorGUILayout.Space(20);
                 EditorGUILayout.LabelField("", GUI.skin.horizontalSlider);
                 EditorGUILayout.LabelField("Translate entries by value", EditorStyles.boldLabel);
-                EditorGUILayout.HelpBox("This will search all properties and translate all that have the exact display name with the selected value. Suggested usecase: Panning, UV", MessageType.Info);
+                EditorGUILayout.HelpBox("This will search all properties and translate all that have the exact display name with the selected value. Suggested usage case: Panning, UV", MessageType.Info);
                 GUIValueTranslate(locale);
 
                 EditorGUILayout.Space(20);
@@ -858,25 +860,6 @@ namespace Thry.ThryEditor
 
             void GUICSV(Localization locale)
             {
-                EditorGUILayout.LabelField("Spreadsheet Sync", EditorStyles.boldLabel);
-                EditorGUILayout.HelpBox(
-                    "Use this area to load Localization data from an external CSV file on the internet (ideally from Google Docs Spreadsheet), then click Import.\n\n" +
-                    "Example Format:\nhttps://docs.google.com/spreadsheets/d/<ID>/gviz/tq?tqx=out:csv&sheet=<TAB_NAME>",
-                    MessageType.Info
-                );
-
-                locale.SpreadsheetCsvUrl = EditorGUILayout.TextField("URL", locale.SpreadsheetCsvUrl);
-                using (new EditorGUILayout.HorizontalScope())
-                {
-                    GUI.enabled = !string.IsNullOrWhiteSpace(locale.SpreadsheetCsvUrl);
-                    if (GUILayout.Button("Import Spreadsheet from URL")) ImportOnlineSpreadsheet(locale);
-                    if (GUILayout.Button("Open URL", GUILayout.Width(90))) Application.OpenURL(locale.SpreadsheetCsvUrl);
-                }
-
-                GUI.enabled = true;
-
-                EditorGUILayout.Space();
-                
                 if (GUILayout.Button("Load from CSV")) LoadFromCSV(locale);
 
                 if (locale.Languages.Length == 0)
@@ -889,6 +872,20 @@ namespace Thry.ThryEditor
                 if (GUILayout.Button("Export as CSV")) ExportAsCSV(locale);
 
                 if (GUILayout.Button("Export Missing Properties as CSV")) ExportMissingAsCSV(locale);
+
+                EditorGUILayout.Space();
+
+                EditorGUILayout.LabelField("Spreadsheet Sync", EditorStyles.boldLabel);
+
+                locale.SpreadsheetCsvUrl = EditorGUILayout.TextField("URL", locale.SpreadsheetCsvUrl);
+                using (new EditorGUILayout.HorizontalScope())
+                {
+                    GUI.enabled = !string.IsNullOrWhiteSpace(locale.SpreadsheetCsvUrl);
+                    if (GUILayout.Button("Import Spreadsheet from URL")) ImportOnlineSpreadsheet(locale);
+                    if (GUILayout.Button("Open URL", GUILayout.Width(90))) Application.OpenURL(locale.SpreadsheetCsvUrl);
+                }
+
+                GUI.enabled = true;
 
                 EditorGUILayout.Space();
 

--- a/Editor/Localization.cs
+++ b/Editor/Localization.cs
@@ -595,6 +595,43 @@ namespace Thry.ThryEditor
                 }
             }
 
+            // DEBUG FUNCTION: Export a CSV File only with Properties that don't currently exist in Localization.
+            void ExportMissingAsCSV(Localization locale)
+            {
+                locale.Load();
+                UpdateData(locale);
+
+                HashSet<string> existing = new HashSet<string>();
+                if (locale._keys != null) foreach (var k in locale._keys) if (!string.IsNullOrEmpty(k)) existing.Add(k);
+
+                string path = EditorUtility.SaveFilePanel("Debug: Export Missing Properties as CSV", "", locale.name + "_Missing", "csv");
+                if (string.IsNullOrEmpty(path)) return;
+
+                System.Text.StringBuilder sb = new System.Text.StringBuilder();
+
+                sb.Append(ToCSVString("Property"));
+                sb.Append("," + ToCSVString("English"));
+                foreach (string language in locale.Languages) sb.Append("," + ToCSVString(language));
+                sb.AppendLine();
+
+                foreach (var kvp in _defaultPropertyContent)
+                {
+                    string key = kvp.Key;
+                    if (ShouldIgnoreKey(key)) continue;
+                    if (existing.Contains(key)) continue;
+
+                    string english = kvp.Value ?? "";
+                    sb.Append(ToCSVString(key));
+                    sb.Append("," + ToCSVString(english));
+
+                    for (int j = 0; j < locale.Languages.Length; j++) sb.Append(",");
+
+                    sb.AppendLine();
+                }
+
+                File.WriteAllText(path, sb.ToString(), new System.Text.UTF8Encoding(true));
+            }
+
             void LoadFromCSV(Localization locale)
             {
                 string path = EditorUtility.OpenFilePanel("Load from CSV", "", "csv");
@@ -828,7 +865,7 @@ namespace Thry.ThryEditor
                     MessageType.Info
                 );
 
-                locale.SpreadsheetCsvUrl = EditorGUILayout.TextField("CSV URL", locale.SpreadsheetCsvUrl);
+                locale.SpreadsheetCsvUrl = EditorGUILayout.TextField("URL", locale.SpreadsheetCsvUrl);
                 using (new EditorGUILayout.HorizontalScope())
                 {
                     GUI.enabled = !string.IsNullOrWhiteSpace(locale.SpreadsheetCsvUrl);
@@ -850,6 +887,8 @@ namespace Thry.ThryEditor
                 }
 
                 if (GUILayout.Button("Export as CSV")) ExportAsCSV(locale);
+
+                if (GUILayout.Button("Export Missing Properties as CSV")) ExportMissingAsCSV(locale);
 
                 EditorGUILayout.Space();
 

--- a/Editor/Localization.cs
+++ b/Editor/Localization.cs
@@ -667,6 +667,8 @@ namespace Thry.ThryEditor
                 List<MaterialProperty> allProps = new List<MaterialProperty>();
                 foreach (Shader s in locale.ValidateWithShaders)
                 {
+                    if (s == null) continue;
+                    
                     allProps.AddRange(
                         MaterialEditor.GetMaterialProperties(new Material[] { new Material(s) })
                     );
@@ -814,6 +816,10 @@ namespace Thry.ThryEditor
                     // For each shader create a material & material editor so that the data is loaded into the localization object
                     foreach (Shader s in locale.ValidateWithShaders)
                     {
+                        if (s == null)
+                        {
+                            ThryLogger.LogWarn("[Localization] ValidateWithShaders contains a NULL shader (None). Skipping.");
+                        }
                         ShaderEditor se = new ShaderEditor();
                         se.FakePartialInitilizationForLocaleGathering(s);
                     }

--- a/Editor/ShaderOptimizer.cs
+++ b/Editor/ShaderOptimizer.cs
@@ -2723,6 +2723,8 @@ namespace Thry.ThryEditor
         private static Dictionary<Shader, bool> isShaderUsingThryOptimizer = new Dictionary<Shader, bool>();
         public static bool IsShaderUsingThryOptimizer(Shader shader)
         {
+            if (shader == null) return false;
+            
             if (isShaderUsingThryOptimizer.ContainsKey(shader))
             {
                 return isShaderUsingThryOptimizer[shader];


### PR DESCRIPTION
- Allows community contribution through Spreadsheets be easier by printing English text into Column B, with translated text now starting from Column C.
- Fixes a bug where empty translations did not print text in the UI. Empty translations are now replaced with English.
- Fixed broken Inspector when editing shaders to validate with.
- Fix for NullReferenceExceptions on `key` parameter by checking for data and returning on missing/inconsistent entries.
   - This required an update to ShaderOptimizer.cs so that it's hardened against null shaders.
- Backwards-compatible with old format.
- **Overhauled the CSV Handling by allowing manual remote syncing with a Google Docs Spreadsheet, using a CSV endpoint to read and apply data directly from Unity Editor. This is backwards-compatible and allows remote syncing localization data on past, present, and future versions of Poiyomi Shaders.**
- **Quotation Marks are now enforced in the CSV Handling to prevent comma-separated value errors in translated text, fixing a long-standing flaw that broke translated text due to usage of commas in sentences.**
- Properties starting with `s_end_*`, `m_end_*`, and `ss_end_`, which aren't shown in the UI (only used for Thry Editor GUI formatting) are ignored and will not show in the Missing Entries.
- Locale Timestamp and Locale.csv file is added to Project anytime it's updated for backup and timekeeping purposes.
- Many null checks added, fixing various bugs.

### Due to the sheer amount of changes in this PR, a **minor** version increment is recommended.