### PR TITLE
Re-aligned Notes Padding for new UI

### DIFF
--- a/Editor/Config.cs
+++ b/Editor/Config.cs
@@ -11,7 +11,7 @@ namespace Thry.ThryEditor
     public class Config
     {
         private const string PATH_CONFIG_FILE = "Thry/Config.json";
-        private static readonly Version INSTALLED_VERSION = "2.70.2";
+        private static readonly Version INSTALLED_VERSION = "2.70.3";
 
         private static Config s_config;
 

--- a/Editor/Styles.cs
+++ b/Editor/Styles.cs
@@ -136,7 +136,7 @@ namespace Thry.ThryEditor
 					_label_property_note = new GUIStyle(EditorStyles.label)
 					{
 						alignment = TextAnchor.MiddleRight,
-						padding = new RectOffset(0, 0, 0, 4),
+						padding = new RectOffset(0, 0, 0, 0),
 						normal = new GUIStyleState { textColor = EditorGUIUtility.isProSkin ? new Color(1f, 1f, 1f, 0.6f) : new Color(0f, 0f, 0f, 1f) }
 					};
 				}


### PR DESCRIPTION
This line change fixes `label_property_note` from being vertically offset, so that it now supports the upcoming 10.0 UI updates from Poiyomi.