### PR TITLE
Fixed missing Shader Editor Repaint on Texture Array.cs

### DIFF
--- a/Editor/Drawers/TextureArray.cs
+++ b/Editor/Drawers/TextureArray.cs
@@ -53,6 +53,7 @@ namespace Thry.ThryEditor.Drawers
             UpdateFramesProperty(shaderProperty, tex);
             if (fps > 0)
                 UpdateFpsProperty(shaderProperty, fps);
+            ShaderEditor.RepaintActive();
             EditorGUIUtility.ExitGUI();
         }
 


### PR DESCRIPTION
This prevents the Shader UI from breaking after converting a GIF to Texture Array when only inspecting a Material (not through a Mesh Renderer!).

Added on Line 56, please use `ShaderEditor.RepaintActive();` before executing `ExitGUI();` in HanldeDropEvent.