### PR TITLE
ShaderOptimizer Enhancements

### DIFF
--- a/Editor/ShaderOptimizer.cs
+++ b/Editor/ShaderOptimizer.cs
@@ -519,6 +519,18 @@ namespace Thry.ThryEditor
             SetLockForAllChildrenInternal(Selection.gameObjects, 1, true);
         }
 
+        [MenuItem("GameObject/Thry/Materials/Unlock Renderers", false,0)]
+        static void UnlockRenderersOnly()
+        {
+            SetLockForAllChildrenRenderersOnlyInternal(Selection.gameObjects, 0, true);
+        }
+
+        [MenuItem("GameObject/Thry/Materials/Lock Renderers", false,0)]
+        static void LockRenderersOnly()
+        {
+            SetLockForAllChildrenRenderersOnlyInternal(Selection.gameObjects, 1, true);
+        }
+
         //---Asset Unlocking
 
         [MenuItem("Assets/Thry/Materials/Unlock All", false, 303)]
@@ -816,6 +828,13 @@ namespace Thry.ThryEditor
         public static bool SetLockedForAllMaterials(IEnumerable<Material> materials, int lockState, bool showProgressbar = false, bool showDialog = false, bool allowCancel = true, MaterialProperty shaderOptimizerProp = null)
         {
             return SetLockedForAllMaterialsInternal(materials, lockState, showProgressbar, showDialog, allowCancel, shaderOptimizerProp);
+        }
+
+        private static bool SetLockForAllChildrenRenderersOnlyInternal(GameObject[] objects, int lockState, bool showProgressbar = false, bool showDialog = false, bool allowCancel = true)
+        {
+            IEnumerable<Material> materials = objects.Where(o => o != null).SelectMany(o => o.GetComponentsInChildren<Renderer>(true)).SelectMany(r => r.sharedMaterials).Where(m => m != null);
+
+            return SetLockedForAllMaterialsInternal(materials, lockState, showProgressbar, showDialog, allowCancel);
         }
 
         private static bool SetLockForAllChildrenInternal(GameObject[] objects, int lockState, bool showProgressbar = false, bool showDialog = false, bool allowCancel = true)
@@ -2618,6 +2637,64 @@ namespace Thry.ThryEditor
         }
 #endregion
 
+#region Animator Clip Checkers
+
+#if (VRC_SDK_VRCSDK2 || VRC_SDK_VRCSDK3) && UNITY_EDITOR
+        private static IEnumerable<AnimationClip> GetClipsFromRuntimeController(RuntimeAnimatorController controller)
+        {
+            if (controller == null) yield break;
+
+            // AnimatorOverrideController wraps another controller and can override clips.
+            AnimatorOverrideController aoc = controller as AnimatorOverrideController;
+            if (aoc != null)
+            {
+                foreach (AnimationClip c in GetClipsFromRuntimeController(aoc.runtimeAnimatorController))
+                {
+                    if (c != null) yield return c;
+                }
+
+                var overrides = new List<KeyValuePair<AnimationClip, AnimationClip>>();
+                aoc.GetOverrides(overrides);
+                foreach (var kv in overrides)
+                {
+                    if (kv.Key != null) yield return kv.Key;
+                    if (kv.Value != null) yield return kv.Value;
+                }
+                yield break;
+            }
+
+            foreach (AnimationClip c in controller.animationClips)
+            {
+                if (c != null) yield return c;
+            }
+        }
+
+        private static IEnumerable<Material> GetMaterialsReferencedByClips(IEnumerable<AnimationClip> clips)
+        {
+            if (clips == null) yield break;
+
+            foreach (AnimationClip clip in clips)
+            {
+                if (clip == null) continue;
+
+                foreach (var binding in AnimationUtility.GetObjectReferenceCurveBindings(clip))
+                {
+                    if (!binding.isPPtrCurve) continue;
+                    if (!binding.type.IsSubclassOf(typeof(Renderer))) continue;
+                    if (!binding.propertyName.StartsWith("m_Materials")) continue;
+
+                    foreach (var key in AnimationUtility.GetObjectReferenceCurve(clip, binding))
+                    {
+                        Material mat = key.value as Material;
+                        if (mat != null) yield return mat;
+                    }
+                }
+            }
+        }
+#endif
+
+#endregion
+
 #region VRC Callbacks
 
         //----VRChat Callback to force Locking on upload
@@ -2629,11 +2706,11 @@ namespace Thry.ThryEditor
 
             public bool OnPreprocessAvatar(GameObject avatarGameObject)
             {
-                if(Application.isPlaying) return true;
+                if (Application.isPlaying) return true;
                 List<Material> materials = avatarGameObject.GetComponentsInChildren<Renderer>(true).SelectMany(r => r.sharedMaterials).ToList();
-#if VRC_SDK_VRCSDK3  && !UDON
+#if VRC_SDK_VRCSDK3 && !UDON
                 VRCAvatarDescriptor descriptor = avatarGameObject.GetComponent<VRCAvatarDescriptor>();
-                if(descriptor != null)
+                if (descriptor != null)
                 {
                     IEnumerable<AnimationClip> clips = descriptor.baseAnimationLayers.Select(l => l.animatorController).Where(a => a != null).SelectMany(a => a.animationClips).Distinct();
                     foreach (AnimationClip clip in clips)
@@ -2643,10 +2720,15 @@ namespace Thry.ThryEditor
                         materials.AddRange(clipMaterials);
                     }
                 }
+#if UNITY_EDITOR
+                // Scan all Animator components under the Avatar Root to catch material-swap animations
+                // that aren't part of the VRCAvatarDescriptor layer list (generic Unity approach).
+                IEnumerable<AnimationClip> animatorClips = avatarGameObject.GetComponentsInChildren<Animator>(true).Select(a => a.runtimeAnimatorController).Where(c => c != null).SelectMany(GetClipsFromRuntimeController).Distinct();
 
+                materials.AddRange(GetMaterialsReferencedByClips(animatorClips));
 #endif
-                if(SetLockedForAllMaterialsInternal(materials, 1, showProgressbar: true, showDialog: PersistentData.Get<bool>("ShowLockInDialog", true), allowCancel: false) == false)
-                    return false;
+#endif
+                if (SetLockedForAllMaterialsInternal(materials, 1, showProgressbar: true, showDialog: PersistentData.Get<bool>("ShowLockInDialog", true), allowCancel: false) == false) return false;
                 //returning true all the time, because build process cant be stopped it seems
                 return true;
             }

--- a/Editor/ShaderOptimizer.cs
+++ b/Editor/ShaderOptimizer.cs
@@ -870,6 +870,11 @@ namespace Thry.ThryEditor
         private static bool SetLockedForAllMaterialsInternal(IEnumerable<Material> materials, int lockState, bool showProgressbar = false, bool showDialog = false, bool allowCancel = true, MaterialProperty shaderOptimizerProp = null)
         {
             Helper.RegisterEditorUse();
+
+            // Clear stale state from previous operations. Reference: poiyomi/ThryEditor@5643b45
+            s_applyStructsLater.Clear();
+            s_shaderPropertyCombinations.Clear();
+
             //first the shaders are created. compiling is suppressed with start asset editing
             AssetDatabase.StartAssetEditing();
 
@@ -1339,6 +1344,9 @@ namespace Thry.ThryEditor
             // Will still be a massive n2 operation from each line * each property
             foreach (ParsedShaderFile psf in shaderFiles)
             {
+                // Skip files with no lines (these are markers for already-inlined includes)
+                if (psf.lines == null || psf.lines.Length == 0) continue;
+
                 // replace property names when prop is animated
                 for (int i = 0; i < psf.lines.Length; i++)
                 {
@@ -1916,16 +1924,25 @@ namespace Thry.ThryEditor
                     int lastQuotation = lineParsed.IndexOf('\"',firstQuotation+1);
                     string includeFilename = lineParsed.Substring(firstQuotation+1, lastQuotation-firstQuotation-1);
 
-                    // Skip default includes
+                    // Skip default includes - keep them as #include statements
                     if (DefaultUnityShaderIncludes.Contains(includeFilename) == false)
                     {
                         string includeFullpath = includeFilename;
                         if (includeFilename.StartsWith("Assets/", StringComparison.Ordinal) == false && includeFilename.StartsWith("Packages/", StringComparison.Ordinal) == false) // not absolute
                             includeFullpath = GetFullPath(includeFilename, Path.GetDirectoryName(filePath));
-                        if (!ParseShaderFilesRecursive(filesParsed, newTopLevelDirectory, includeFullpath, macros, material, stripTextures))
-                            return false;
-                        // Change include to be be ralative to only one directory up, because all files are moved into the same folder
-                        fileLines[i] = fileLines[i].Replace(includeFilename, "/"+includeFilename.Split('/').Last());
+                        
+                        // Convert Unity asset path to absolute filesystem path for Packages. Reference: poiyomi/ThryEditor@9cde7a0
+                        if (includeFullpath.StartsWith("Packages/", StringComparison.Ordinal)) includeFullpath = Path.GetFullPath(includeFullpath);
+                        // Inline the include contents instead of keeping the #include
+                        string[] inlinedLines = GetInlinedIncludeLines(includeFullpath, macros, material, stripTextures, filesParsed);
+                        if (inlinedLines == null) return false;
+                        includedLines.Add($"// [Inlined] {includeFilename}");
+
+                        includedLines.AddRange(inlinedLines);
+
+                        includedLines.Add($"// [End Inlined] {includeFilename}");
+
+                        continue; // Don't add the #include line itself
                     }
                 }
 
@@ -1975,6 +1992,115 @@ namespace Thry.ThryEditor
                 relativePath = relativePath.Remove(0, "../".Length);
             }
             return basePath + '/' + relativePath;
+        }
+
+        // Helper to read and process include file contents for inlining. Reference: poiyomi/ThryEditor@9cde7a0
+        private static string[] GetInlinedIncludeLines(string filePath, List<Macro> macros, Material material, List<string> stripTextures, List<ParsedShaderFile> alreadyProcessed)
+        {
+            // Infinite recursion check
+            if (alreadyProcessed.Exists(x => x.filePath == filePath)) return new string[0]; // Already included, return empty to avoid duplicates
+
+            // Mark as processed to prevent infinite recursion
+            ParsedShaderFile marker = new ParsedShaderFile();
+            marker.filePath = filePath;
+            marker.lines = new string[0]; // Empty - we're inlining, not writing separately
+            alreadyProcessed.Add(marker);
+
+            string fileContents = null;
+            try
+            {
+                StreamReader sr = new StreamReader(filePath);
+                fileContents = sr.ReadToEnd();
+                sr.Close();
+            }
+            catch (FileNotFoundException e)
+            {
+                Debug.LogError("[Shader Optimizer] Include file " + filePath + " not found. " + e.ToString());
+                return null;
+            }
+            catch (IOException e)
+            {
+                Debug.LogError("[Shader Optimizer] Error reading include file. " + e.ToString());
+                return null;
+            }
+
+            string[] fileLines = fileContents.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+            List<string> resultLines = new List<string>();
+            bool isCommentedOut = false;
+            int currentExcludeDepth = 0;
+            bool doExclude = false;
+            int excludeStartDepth = 0;
+
+            for (int i = 0; i < fileLines.Length; i++)
+            {
+                string lineParsed = fileLines[i].TrimStart();
+
+                // Handle comments
+                if (lineParsed.StartsWith("//", StringComparison.Ordinal))
+                {
+                    if (lineParsed.StartsWith("//ifex", StringComparison.Ordinal))
+                    {
+                        if (!doExclude)
+                        {
+                            var condition = DefineableCondition.Parse(lineParsed.Substring(6), material);
+                            if (condition.Test())
+                            {
+                                doExclude = true;
+                                excludeStartDepth = currentExcludeDepth;
+                            }
+                        }
+                        currentExcludeDepth++;
+                    }
+                    else if (lineParsed.StartsWith("//endex", StringComparison.Ordinal))
+                    {
+                        if (currentExcludeDepth > 0)
+                        {
+                            currentExcludeDepth--;
+                            if (currentExcludeDepth == excludeStartDepth) doExclude = false;
+                        }
+                    }
+                    continue;
+                }
+                if (doExclude) continue;
+                if (string.IsNullOrEmpty(lineParsed)) continue;
+
+                // Handle block comments
+                if (isCommentedOut && lineParsed.EndsWith("*/", StringComparison.OrdinalIgnoreCase))
+                {
+                    isCommentedOut = false;
+                    continue;
+                }
+                else if (lineParsed.StartsWith("/*", StringComparison.OrdinalIgnoreCase))
+                {
+                    isCommentedOut = true;
+                    continue;
+                }
+                if (isCommentedOut) continue;
+
+                // Handle nested includes - inline them too
+                if (lineParsed.StartsWith("#include", StringComparison.Ordinal))
+                {
+                    int firstQuotation = lineParsed.IndexOf('\"', 0);
+                    int lastQuotation = lineParsed.IndexOf('\"', firstQuotation + 1);
+                    string includeFilename = lineParsed.Substring(firstQuotation + 1, lastQuotation - firstQuotation - 1);
+
+                    if (DefaultUnityShaderIncludes.Contains(includeFilename) == false)
+                    {
+                        string includeFullpath = includeFilename;
+                        if (includeFilename.StartsWith("Assets/", StringComparison.Ordinal) == false && includeFilename.StartsWith("Packages/", StringComparison.Ordinal) == false) includeFullpath = GetFullPath(includeFilename, Path.GetDirectoryName(filePath));
+                        string[] nestedLines = GetInlinedIncludeLines(includeFullpath, macros, material, stripTextures, alreadyProcessed);
+                        if (nestedLines == null) return null;
+                        resultLines.Add($"// [Inlined] {includeFilename}");
+                        resultLines.AddRange(nestedLines);
+                        resultLines.Add($"// [End Inlined] {includeFilename}");
+                        continue;
+                    }
+                }
+
+                resultLines.Add(fileLines[i]);
+            }
+
+            return resultLines.ToArray();
         }
 
         // Replace properties! The meat of the shader optimization process


### PR DESCRIPTION
This Pull Request enhances some functions of ShaderOptimizer.cs by adding a helpful debugging solution and fixing some overlooked issues I've found.

- Changes `Thry -> Materials -> Lock All` to also lock animated material swaps.
   - `LockMaterialsOnUpload.OnPreprocessAvatar` already does this at Build, but the same functionality used to force lock materials found in animation clips (used for material swaps) is now used for the manual Lock All function as well. This patches a flaw on the expected functionality of Lock All.
   - This only works if Lock All is executed while selecting the Avatar Root.
   - Old functionality is preserved in new `Thry -> Materials -> Lock Renderers` option.
- Added traceback methods to shaders left unlocked on build.
   - If Shaders failed to lock, the script will now tell the user through the Console output where the problematic materials are located. This will greatly assist with debugging in the future.
- Reduced amount of text in Unlocked Shader dialog because it was exceeding text limitations.
- `LockMaterialsOnUpload.OnPreprocessAvatar` will now catch material animations that are not part of the VRC Avatar Layers and lock them.
   - This is done through a generic Unity Editor approach, which should hopefully make it future-proof against any other non-destructive utilities out there.
- Added code changes from Poiyomi's fork.
   - Clear stale shader optimizer states: poiyomi/ThryEditor@5643b45
   - Inline .cginc contents in locked shaders instead of copying files: poiyomi/ThryEditor@9cde7a0