### PR TITLE
Fix Unity crash on shader linker when a material is deleted

### DIFF
--- a/Editor/MaterialLinker.cs
+++ b/Editor/MaterialLinker.cs
@@ -70,7 +70,7 @@ namespace Thry.ThryEditor
         {
             Load();
             if(linked_materials.TryGetValue((m,p.name), out List<Material> links))
-                return links.Where(l => l != m);
+                return links.Where(l => l != m && l != null);
             return null;
         }
 


### PR DESCRIPTION
When a material that is linked to another is deleted, opening the link menu on any of the other linked materials causes a unity crash as one of the linked materials is null.

Simplest fix is null filtering on `static IEnumerable<Material> Thry.ThryEditor.MaterialLinker.GetLinked(Material m, MaterialProperty p)`

Truncated crash log without the fix
```
Received signal SIGSEGV
(Unity) Material::GetFloat
(Unity) ExtractMonoMaterialProperty
(Unity) ShaderUtil::GetMaterialPropertyImpl
(Unity) ShaderUtil_CUSTOM_GetMaterialPropertyImpl
(Mono JIT Code) (wrapper managed-to-native) UnityEditor.ShaderUtil:GetMaterialPropertyImpl (object,string)
(Mono JIT Code) UnityEditor.ShaderUtil:GetMaterialProperty (UnityEngine.Object[],string)
(Mono JIT Code) UnityEditor.MaterialEditor:GetMaterialProperty (UnityEngine.Object[],string)
(Mono JIT Code) Thry.ThryEditor.Helpers.MaterialHelper:CopyValue (UnityEditor.MaterialProperty,UnityEngine.Material[]) (at ./Packages/com.poiyomi.toon/_PoiyomiShaders/Scripts/ThryEditor/Editor/Helpers/MaterialHelper.cs:170)
(Mono JIT Code) Thry.ThryEditor.ShaderProperty:CopyTo (UnityEngine.Material[],bool,bool,bool,System.Collections.Generic.HashSet`1<UnityEditor.MaterialProperty/PropType>,System.Collections.Generic.HashSet`1<string>) (at ./Packages/com.poiyomi.toon/_PoiyomiShaders/Scripts/ThryEditor/Editor/EditorStructs/ShaderProperty.cs:179)
(Mono JIT Code) Thry.ThryEditor.ShaderPart:CopyReferencePropertiesTo (UnityEngine.Material[],System.Collections.Generic.HashSet`1<UnityEditor.MaterialProperty/PropType>,System.Collections.Generic.HashSet`1<string>) (at ./Packages/com.poiyomi.toon/_PoiyomiShaders/Scripts/ThryEditor/Editor/EditorStructs/ShaderPart.cs:638)
(Mono JIT Code) Thry.ThryEditor.ShaderGroup:CopyTo (UnityEngine.Material[],bool,bool,bool,System.Collections.Generic.HashSet`1<UnityEditor.MaterialProperty/PropType>,System.Collections.Generic.HashSet`1<string>) (at ./Packages/com.poiyomi.toon/_PoiyomiShaders/Scripts/ThryEditor/Editor/EditorStructs/ShaderGroup.cs:152)
(Mono JIT Code) Thry.ThryEditor.ShaderGroup:UpdateLinkedMaterials () (at ./Packages/com.poiyomi.toon/_PoiyomiShaders/Scripts/ThryEditor/Editor/EditorStructs/ShaderGroup.cs:202)
(Mono JIT Code) Thry.ThryEditor.ShaderHeader:DrawInternal (UnityEngine.GUIContent,System.Nullable`1<UnityEngine.Rect>,bool,bool) (at ./Packages/com.poiyomi.toon/_PoiyomiShaders/Scripts/ThryEditor/Editor/EditorStructs/ShaderHeader.cs:51)
(Mono JIT Code) Thry.ThryEditor.ShaderPart:PerformDraw (UnityEngine.GUIContent,System.Nullable`1<UnityEngine.Rect>,bool,bool) (at ./Packages/com.poiyomi.toon/_PoiyomiShaders/Scripts/ThryEditor/Editor/EditorStructs/ShaderPart.cs:734)
(Mono JIT Code) Thry.ThryEditor.ShaderPart:Draw (System.Nullable`1<UnityEngine.Rect>,UnityEngine.GUIContent,bool,bool) (at ./Packages/com.poiyomi.toon/_PoiyomiShaders/Scripts/ThryEditor/Editor/EditorStructs/ShaderPart.cs:717)
(Mono JIT Code) Thry.ThryEditor.ShaderHeader:DrawInternal (UnityEngine.GUIContent,System.Nullable`1<UnityEngine.Rect>,bool,bool) (at ./Packages/com.poiyomi.toon/_PoiyomiShaders/Scripts/ThryEditor/Editor/EditorStructs/ShaderHeader.cs:42)
(Mono JIT Code) Thry.ThryEditor.ShaderPart:PerformDraw (UnityEngine.GUIContent,System.Nullable`1<UnityEngine.Rect>,bool,bool) (at ./Packages/com.poiyomi.toon/_PoiyomiShaders/Scripts/ThryEditor/Editor/EditorStructs/ShaderPart.cs:734)
(Mono JIT Code) Thry.ThryEditor.ShaderPart:Draw (System.Nullable`1<UnityEngine.Rect>,UnityEngine.GUIContent,bool,bool) (at ./Packages/com.poiyomi.toon/_PoiyomiShaders/Scripts/ThryEditor/Editor/EditorStructs/ShaderPart.cs:717)
(Mono JIT Code) Thry.ShaderEditor:Draw () (at ./Packages/com.poiyomi.toon/_PoiyomiShaders/Scripts/ThryEditor/Editor/ThryEditor.cs:658)
```